### PR TITLE
Add webkit (safari) vendor prefix for position sticky

### DIFF
--- a/src/components/Navbar/Navbar.sass
+++ b/src/components/Navbar/Navbar.sass
@@ -2,7 +2,7 @@ $background-color: rgba(255, 255, 255, 0.6)
 $border-color: rgba(140, 140, 140, 0.1)
 
 .container
-  position: sticky
+  @include sticky
   top: 0
   left: 0
   z-index: $low

--- a/src/styles/_mixins.sass
+++ b/src/styles/_mixins.sass
@@ -9,3 +9,7 @@
   overflow: hidden
   white-space: nowrap
   direction: $direction
+
+@mixin sticky()
+  position: -webkit-sticky
+  position: sticky


### PR DESCRIPTION
Closes #25 in that the `position: sticky` has been properly vendor-prefixed for webkit safari. After trying to set up the autoprefixer with webpack, the final solution was to simply create a mixin with the webkit prefix included in the definition.