### PR TITLE
Issue 27 html color parse bug

### DIFF
--- a/helpers/regular-expressions.js
+++ b/helpers/regular-expressions.js
@@ -168,7 +168,7 @@ const HTML_COLOR_NAMES = [
 // Html Color Names
 const htmlColorName = str => {
   const normalizedStringArray = str
-    .replace(/[^a-z]/gi, ' ')
+    .replace(/[^a-zA-Z$@]/gi, ' ')
     .toLowerCase()
     .split(/\s/gi);
 

--- a/helpers/regular-expressions.js
+++ b/helpers/regular-expressions.js
@@ -168,7 +168,7 @@ const HTML_COLOR_NAMES = [
 // Html Color Names
 const htmlColorName = str => {
   const normalizedStringArray = str
-    .replace(/[^a-zA-Z$@]/gi, ' ')
+    .replace(/[^a-zA-Z$@.#-]/gi, ' ')
     .toLowerCase()
     .split(/\s/gi);
 

--- a/tests/regular-expressions.test.js
+++ b/tests/regular-expressions.test.js
@@ -157,6 +157,7 @@ describe('Test HSL(A) Regular Expression Parsing', () => {
 describe('Test HTML Color Name Parsing', () => {
   test('Should match valid Html color names', () => {
     expect(htmlColorName('darkred')).toEqual(['darkred']);
+    expect(htmlColorName('"darkred"')).toEqual(['darkred']);
     expect(htmlColorName('aliceblue, darkred')).toEqual([
       'aliceblue',
       'darkred',
@@ -208,6 +209,9 @@ describe('Test HTML Color Name Parsing', () => {
     expect(htmlColorName('bluebyou')).toBeNull();
     expect(htmlColorName('steelblues')).toBeNull();
     expect(htmlColorName('$blue')).toBeNull();
+    expect(htmlColorName('.blue')).toBeNull();
+    expect(htmlColorName('#blue')).toBeNull();
+    expect(htmlColorName('-blue')).toBeNull();
   });
 });
 

--- a/tests/regular-expressions.test.js
+++ b/tests/regular-expressions.test.js
@@ -207,6 +207,7 @@ describe('Test HTML Color Name Parsing', () => {
     expect(htmlColorName('lightslategraymediumorchiddeepskyblue')).toBeNull();
     expect(htmlColorName('bluebyou')).toBeNull();
     expect(htmlColorName('steelblues')).toBeNull();
+    expect(htmlColorName('$blue')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Closes #27 by updating the regex in the `htmlColorName()` function to exclude parsing out sass/less variables and class names.