### PR TITLE
Fix keyboard controls not working in webkit

### DIFF
--- a/src/containers/pages/DetailContainer.jsx
+++ b/src/containers/pages/DetailContainer.jsx
@@ -6,9 +6,7 @@ import {closeColorDetail, openColorDetail} from 'redux/actionCreators';
 
 import {toggleStaticBody} from 'utils/misc';
 
-import {
-  Detail,
-} from 'components';
+import {Detail} from 'components';
 
 
 class DetailContainer extends React.Component {
@@ -26,12 +24,12 @@ class DetailContainer extends React.Component {
 
   componentDidMount = () => {
     toggleStaticBody();
-    document.addEventListener('keypress', this.handleKeyPress);
+    document.addEventListener('keydown', this.handleKeyPress);
   }
 
   componentWillUnmount = () => {
     toggleStaticBody(false);
-    document.removeEventListener('keypress', this.handleKeyPress);
+    document.removeEventListener('keydown', this.handleKeyPress);
   }
 
   handleKeyPress = event => {


### PR DESCRIPTION
Fixes #65 

- Replaced `keypress` with `keydown` because the later works for keys that do not print a character.