### PR TITLE
Change the ColorSwatch to open on click rather than via the icon.

### DIFF
--- a/src/components/blocks/ColorList/ColorList.jsx
+++ b/src/components/blocks/ColorList/ColorList.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import tinycolor from 'tinycolor2';
 
 import {getTextColor} from 'utils/color-manipulation';
+import {triggerIfEnterKey} from 'utils/misc';
 
 import s from './ColorList.sass';
 
@@ -23,6 +24,14 @@ const ColorList = ({palette, openColorDetail}) => (
               <tr
                 className={s.row}
                 onClick={() => { openColorDetail(color); }}
+                onKeyDown={event => {
+                  triggerIfEnterKey(
+                    event,
+                    () => { openColorDetail(color); },
+                  );
+                }}
+                tabIndex="0"
+                role="button"
                 style={{backgroundColor: color, color: getTextColor(color)}}
                 key={key}
               >
@@ -50,6 +59,14 @@ const ColorList = ({palette, openColorDetail}) => (
               <tr
                 className={s.row}
                 onClick={() => { openColorDetail(color); }}
+                onKeyDown={event => {
+                  triggerIfEnterKey(
+                    event,
+                    () => { openColorDetail(color); },
+                  );
+                }}
+                tabIndex="0"
+                role="button"
                 key={key}
               >
                 <td

--- a/src/components/blocks/ColorList/ColorList.sass
+++ b/src/components/blocks/ColorList/ColorList.sass
@@ -10,7 +10,8 @@
   transition: transform 150ms ease-in-out, box-shadow 150ms ease-in-out
   cursor: pointer
   font-weight: lighter
-  &:hover
+  &:hover, &:focus
+    outline: none;
     transform: scale(1.01)
     box-shadow: 0 15px 35px rgba(50,50,93,.1),0 5px 15px rgba(0,0,0,.07)
   @media (hover: none)

--- a/src/components/core/ColorSwatch/ColorSwatch.jsx
+++ b/src/components/core/ColorSwatch/ColorSwatch.jsx
@@ -4,7 +4,8 @@ import CopyToClipboard from 'react-copy-to-clipboard';
 
 import CopyIcon from 'react-icons/lib/io/ios-copy';
 import CheckMarkIcon from 'react-icons/lib/io/checkmark';
-import TiArrowMaximise from 'react-icons/lib/ti/arrow-maximise';
+
+import {triggerIfEnterKey} from 'utils/misc';
 
 import s from './ColorSwatch.sass';
 
@@ -19,6 +20,12 @@ const ColorSwatch = ({
   <div
     style={{backgroundColor: normalizedColor}}
     className={s.container}
+    onClick={openColorDetail}
+    onKeyDown={event => {
+      triggerIfEnterKey(event, openColorDetail);
+    }}
+    tabIndex="0"
+    role="button"
   >
     <div className={s.icons}>
       <CopyToClipboard text={normalizedColor}>
@@ -28,19 +35,15 @@ const ColorSwatch = ({
           ) : (
             <CopyIcon
               className={s.icon}
-              onClick={copiedToClipboard}
+              onClick={event => {
+                event.stopPropagation();
+                copiedToClipboard(event);
+              }}
               style={{color: textColor}}
             />
           )}
         </a>
       </CopyToClipboard>
-      <a title="Expand Color Details">
-        <TiArrowMaximise
-          style={{color: textColor}}
-          className={s.icon}
-          onClick={openColorDetail}
-        />
-      </a>
     </div>
     <span style={{color: textColor}}>
       {hasCopied ? 'Copied to Clipboard' : normalizedColor}

--- a/src/components/core/ColorSwatch/ColorSwatch.sass
+++ b/src/components/core/ColorSwatch/ColorSwatch.sass
@@ -30,7 +30,11 @@
   border-radius: 0.05em
   font-weight: $lighter
   box-shadow: 0 15px 35px rgba(50,50,93,.1),0 5px 15px rgba(0,0,0,.07)
+  cursor: pointer
   transition: transform 400ms ease-in-out
+  &:focus
+    outline: none
+    transform: scale(1.1)
   &:hover
     transform: scale(1.1)
     .icons


### PR DESCRIPTION
Additionally improved accessibility by making the Color Swatches and
the Color List focusable and openable via the enter key.

Fixes #74 